### PR TITLE
fix: adding function to ./utils/utils.py to clear any env vars that are injected at terminal startup so gateway demo traces correctly

### DIFF
--- a/modules/03_deploy_and_govern.ipynb
+++ b/modules/03_deploy_and_govern.ipynb
@@ -134,6 +134,10 @@
    "source": [
     "from deepagents import create_deep_agent\n",
     "from langchain.chat_models import init_chat_model\n",
+    "from utils.utils import clear_local_env_vars\n",
+    "\n",
+    "# Ensure this local demo uses the workshop's gateway key, not any company-gateway overrides.\n",
+    "clear_local_env_vars()\n",
     "\n",
     "gateway_model = init_chat_model(\n",
     "    model=\"gpt-5.4-mini\",\n",
@@ -166,7 +170,7 @@
    "source": [
     "### 1.3 Watch the policy in action\n",
     "\n",
-    "Same agent, same gateway, but the prompt below carries a (fake) Social Security Number. The gateway inspects the request, matches the `guard` policy, and intercepts the PII before forwarding upstream.\n",
+    "Same agent, same gateway, but the prompt below carries a (fake) email. The gateway inspects the request, matches the `guard` policy, and intercepts the PII before forwarding upstream.\n",
     "\n",
     "The text response won't reveal whether enforcement happened — a clean response comes back either way. To see the effect, open this run's trace in LangSmith: the request payload the gateway sent upstream will show the PII removed."
    ]

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,9 +1,23 @@
 """Shared helpers used by Module 1 (Chinook demo) and others."""
 
+import os
 import sqlite3
 import requests
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
+
+
+def clear_local_env_vars():
+    """Drop company-gateway env vars that would override our service key for this local demo invocation."""
+    for _var in (
+        "ANTHROPIC_CUSTOM_HEADERS",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    ):
+        os.environ.pop(_var, None)
 
 
 def show_graph(graph, xray=False):


### PR DESCRIPTION
Any locally injected env vars from a zshrc will cause override local env vars set in code and cause the demo to trace to the wrong tracing project. Adding a function to clear these so that env vars set in code will persist.